### PR TITLE
[SyntaxParser] -- require input to be array to avoid enumerator boxings

### DIFF
--- a/SyntaxParser/SyntaxEnumerator.cs
+++ b/SyntaxParser/SyntaxEnumerator.cs
@@ -14,7 +14,7 @@ public ref struct SyntaxEnumerator
 
     const int separatorLength = 1;
 
-    internal SyntaxEnumerator(ReadOnlySpan<char> span, ICollection<SyntaxPair> syntaxPairs, char separator)
+    internal SyntaxEnumerator(ReadOnlySpan<char> span, SyntaxPair[] syntaxPairs, char separator)
     {
         _span = span;
         _splitBlocker = new SyntaxSplitBlocker(syntaxPairs);

--- a/SyntaxParser/SyntaxParser.Static.cs
+++ b/SyntaxParser/SyntaxParser.Static.cs
@@ -3,8 +3,8 @@
 public partial class SyntaxParser
 {
 #if NETFRAMEWORK
-    /// <inheritdoc cref="Split(ReadOnlySpan{char}, ICollection{SyntaxPair}, char)"/>
-    public static SyntaxEnumerator Split(string input, ICollection<SyntaxPair> syntaxPairs, char separator)
+    /// <inheritdoc cref="Split(ReadOnlySpan{char}, SyntaxPair[], char)"/>
+    public static SyntaxEnumerator Split(string input, SyntaxPair[] syntaxPairs, char separator)
         => Split(input.AsSpan(), syntaxPairs, separator);
 #endif
 
@@ -14,12 +14,12 @@ public partial class SyntaxParser
     /// <param name="input">The characters to split.</param>
     /// <param name="syntaxPairs">The supported syntax identifiers to look out for.</param>
     /// <param name="separator">The separator to split on.</param>
-    public static SyntaxEnumerator Split(ReadOnlySpan<char> input, ICollection<SyntaxPair> syntaxPairs, char separator)
+    public static SyntaxEnumerator Split(ReadOnlySpan<char> input, SyntaxPair[] syntaxPairs, char separator)
         => new SyntaxEnumerator(input, syntaxPairs, separator);
 
 #if NETFRAMEWORK
-    /// <inheritdoc cref="SliceInBetween(ReadOnlySpan{char}, ICollection{SyntaxPair}, char, char, out ReadOnlySpan{char})"/>
-    public static ReadOnlySpan<char> SliceInBetween(string input, ICollection<SyntaxPair> syntaxPairs, char start, char end, out ReadOnlySpan<char> remainder)
+    /// <inheritdoc cref="SliceInBetween(ReadOnlySpan{char}, SyntaxPair[], char, char, out ReadOnlySpan{char})"/>
+    public static ReadOnlySpan<char> SliceInBetween(string input, SyntaxPair[] syntaxPairs, char start, char end, out ReadOnlySpan<char> remainder)
         => SliceInBetween(input.AsSpan(), syntaxPairs, start, end, out remainder);
 #endif
 
@@ -35,7 +35,7 @@ public partial class SyntaxParser
     /// The slice will only be performed on the outer-most <paramref name="start"/> and <paramref name="end"/>.<br/>
     /// Slicing may therefore fail if the amount of both does not add up.
     /// </remarks>
-    public static ReadOnlySpan<char> SliceInBetween(ReadOnlySpan<char> input, ICollection<SyntaxPair> syntaxPairs, char start, char end, out ReadOnlySpan<char> remainder)
+    public static ReadOnlySpan<char> SliceInBetween(ReadOnlySpan<char> input, SyntaxPair[] syntaxPairs, char start, char end, out ReadOnlySpan<char> remainder)
     {
         var splitBlocker = new SyntaxSplitBlocker(syntaxPairs);
 

--- a/SyntaxParser/SyntaxParser.cs
+++ b/SyntaxParser/SyntaxParser.cs
@@ -8,31 +8,31 @@
 /// <param name="separator">The separator to split on.</param>
 /// <param name="start">The start of a slice.</param>
 /// <param name="end">The end of a slice.</param>
-public partial class SyntaxParser(ICollection<SyntaxPair> syntax, char separator, char start, char end)
+public partial class SyntaxParser(SyntaxPair[] syntax, char separator, char start, char end)
 {
-    private readonly ICollection<SyntaxPair> fullSyntax = syntax;
-    private readonly ICollection<SyntaxPair> subsetOfSyntax = syntax.Where(x => x.Start != start).ToArray();
+    private readonly SyntaxPair[] fullSyntax = syntax;
+    private readonly SyntaxPair[] subsetOfSyntax = syntax.Where(x => x.Start != start).ToArray();
     private readonly char separator = separator;
     private readonly char start = start;
     private readonly char end = end;
 
 #if NETFRAMEWORK
-    /// <inheritdoc cref="SyntaxParser.Split(string, ICollection{SyntaxPair}, char)"/>
+    /// <inheritdoc cref="SyntaxParser.Split(string, SyntaxPair[], char)"/>
     public SyntaxEnumerator Split(string input)
         => SyntaxParser.Split(input, fullSyntax, separator);
 #endif
 
-    /// <inheritdoc cref="SyntaxParser.Split(ReadOnlySpan{char}, ICollection{SyntaxPair}, char)"/>
+    /// <inheritdoc cref="SyntaxParser.Split(ReadOnlySpan{char}, SyntaxPair[], char)"/>
     public SyntaxEnumerator Split(ReadOnlySpan<char> input)
         => SyntaxParser.Split(input, fullSyntax, separator);
 
 #if NETFRAMEWORK
-    /// <inheritdoc cref="SyntaxParser.SliceInBetween(string, ICollection{SyntaxPair}, char, char, out ReadOnlySpan{char})"/>
+    /// <inheritdoc cref="SyntaxParser.SliceInBetween(string, SyntaxPair[], char, char, out ReadOnlySpan{char})"/>
     public ReadOnlySpan<char> SliceInBetween(string input, out ReadOnlySpan<char> remainder)
         => SyntaxParser.SliceInBetween(input, subsetOfSyntax, start, end, out remainder);
 #endif
 
-    /// <inheritdoc cref="SyntaxParser.SliceInBetween(ReadOnlySpan{char}, ICollection{SyntaxPair}, char, char, out ReadOnlySpan{char})"/>
+    /// <inheritdoc cref="SyntaxParser.SliceInBetween(ReadOnlySpan{char}, SyntaxPair[], char, char, out ReadOnlySpan{char})"/>
     public ReadOnlySpan<char> SliceInBetween(ReadOnlySpan<char> input, out ReadOnlySpan<char> remainder)
         => SyntaxParser.SliceInBetween(input, subsetOfSyntax, start, end, out remainder);
 }

--- a/SyntaxParser/SyntaxSplitBlocker.cs
+++ b/SyntaxParser/SyntaxSplitBlocker.cs
@@ -4,9 +4,9 @@
 /// An object used to look for syntax identifiers and possibly prevent splitting a string/span at the current position.
 /// </summary>
 /// <param name="syntaxPairs">The supported syntax identifiers to look out for.</param>
-public readonly ref struct SyntaxSplitBlocker(ICollection<SyntaxPair> syntaxPairs)
+public readonly ref struct SyntaxSplitBlocker(SyntaxPair[] syntaxPairs)
 {
-    private readonly ICollection<SyntaxPair> syntaxPairs = syntaxPairs;
+    private readonly SyntaxPair[] syntaxPairs = syntaxPairs;
     private readonly Stack<SyntaxPair> existingSyntax = new();
 
     /// <summary>


### PR DESCRIPTION
## Before
![image](https://github.com/user-attachments/assets/d21cff26-f452-4328-9587-76a6629fe474)

## After
![image](https://github.com/user-attachments/assets/119f1ee1-1c76-4d2d-a3f9-b62f842b8901)
