### PR TITLE
[FlexibleIterator] -- reset index after failed move call

### DIFF
--- a/FlexibleIterator.Tests/FlexibleIterator_ListIteratorTests.cs
+++ b/FlexibleIterator.Tests/FlexibleIterator_ListIteratorTests.cs
@@ -1,4 +1,6 @@
 
+using System.Reflection;
+
 namespace FlexibleIterator.Tests
 {
     public class FlexibleIterator_ListIteratorTests
@@ -132,6 +134,26 @@ namespace FlexibleIterator.Tests
 
             //Assert
             Assert.That(isValid, Is.EqualTo(false));
+        }
+
+        [TestCase(0, 0)]
+        [TestCase(3, 12)]
+        [TestCase(3, -12)]
+        public void Iterator_InvalidMove_ResetsIndex(int setupInstruction, int outOfBoundsInstruction)
+        {
+            //Arrange
+            var iterator = list.GetFlexibleIterator();
+            var indexField = iterator.GetType().GetField("_index", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            //Act
+            iterator.Move(setupInstruction);
+            int index = (int)indexField.GetValue(iterator)!;
+
+            iterator.Move(outOfBoundsInstruction);
+            int newIndex = (int)indexField.GetValue(iterator)!;
+
+            //Assert
+            Assert.That(newIndex, Is.EqualTo(index));
         }
     }
 }

--- a/FlexibleIterator/ListIterator.cs
+++ b/FlexibleIterator/ListIterator.cs
@@ -71,12 +71,17 @@ namespace FlexibleIterator
         /// <inheritdoc/>
         public bool Move(int offset)
         {
+            int index = _index;
+
             if (offset > 0)
             {
                 for (int i = 0; i < offset; i++)
                 {
                     if (!MoveNext())
+                    {
+                        _index = index;
                         return false;
+                    }
                 }
                 return true;
             }
@@ -91,7 +96,10 @@ namespace FlexibleIterator
                 for (int i = 0; i > offset; i--)
                 {
                     if (!MovePrevious())
+                    {
+                        _index = index;
                         return false;
+                    }
                 }
                 return true;
             }


### PR DESCRIPTION
Not sure if this behavior is unexpected because:
- MoveNext() advances index no matter what
- Move(1) resets index when out of bounds